### PR TITLE
Addition of including uaMessageIdentifier element and retrieving evidence type

### DIFF
--- a/peppol-evidence/src/main/java/no/difi/vefa/peppol/evidence/rem/RemEvidenceBuilder.java
+++ b/peppol-evidence/src/main/java/no/difi/vefa/peppol/evidence/rem/RemEvidenceBuilder.java
@@ -43,6 +43,9 @@ public class RemEvidenceBuilder {
     private String evidenceIssuerDetails;
     private String evidenceIssuerPolicyID;
     
+    // This will used to set the uaMessageIdentifier element
+    private String documentTypeInstanceId;
+    
     // The timestamp of the delivery, defaults to current date and time.
     private Date eventTime = new Date();
 
@@ -123,10 +126,14 @@ public class RemEvidenceBuilder {
      *
      * @param remEvidenceType
      * @param documentTypeId
+     * @param documentTypeInstanceId
      * @param instanceIdentifier
      * @param payloadDigest
      */
-    static void injectTransmissionMetaData(REMEvidenceType remEvidenceType, String documentTypeId, String instanceIdentifier, byte[] payloadDigest) {
+    static void injectTransmissionMetaData(REMEvidenceType remEvidenceType, 
+                                           String documentTypeId,
+                                           String documentTypeInstanceId,
+                                           String instanceIdentifier, byte[] payloadDigest) {
         // Sender message details
         MessageDetailsType messageDetailsType = new MessageDetailsType();
         remEvidenceType.setSenderMessageDetails(messageDetailsType);
@@ -137,6 +144,10 @@ public class RemEvidenceBuilder {
         } else
             throw new IllegalStateException("Must supply document type identifier");
 
+        // Document type instance id from SBDH
+        if (documentTypeInstanceId != null)
+            messageDetailsType.setUAMessageIdentifier(documentTypeInstanceId);
+        
         // Instance identifier from SBDH
         if (instanceIdentifier != null) {
             messageDetailsType.setMessageIdentifierByREMMD(instanceIdentifier);
@@ -199,11 +210,15 @@ public class RemEvidenceBuilder {
     }
 
     public RemEvidenceBuilder documentTypeId(DocumentTypeIdentifier documentTypeId) {
-
         this.documentTypeId = documentTypeId;
         return this;
     }
 
+    public RemEvidenceBuilder documentTypeInstanceIdentifier(String documentTypeInstanceId) {
+        this.documentTypeInstanceId = documentTypeInstanceId;
+        return this;
+    }
+    
     /**
      * The value of <code>//DocumentIdentification/InstanceIdentifier</code> from the SBDH.
      *
@@ -316,7 +331,8 @@ public class RemEvidenceBuilder {
         }
 
 
-        injectTransmissionMetaData(r, documentTypeId.getIdentifier(), instanceIdentifier.getValue(), payloadDigest);
+        injectTransmissionMetaData(r, documentTypeId.getIdentifier(), documentTypeInstanceId,
+                                    instanceIdentifier.getValue(), payloadDigest);
 
         // Injects the transport level receipt (if supplied), i.e. AS2 MDN or AS4 Soap Header
         if (protocolSpecificBytes != null)

--- a/peppol-evidence/src/main/java/no/difi/vefa/peppol/evidence/rem/SignedRemEvidence.java
+++ b/peppol-evidence/src/main/java/no/difi/vefa/peppol/evidence/rem/SignedRemEvidence.java
@@ -47,6 +47,26 @@ public class SignedRemEvidence {
         return signedRemEvidenceXml;
     }
 
+    public EvidenceTypeInstance getEvidenceType() {
+        try {
+            String evElementName = signedRemEvidenceXml.getDocumentElement().getLocalName();
+            switch (evElementName) {
+                case "DeliveryNonDeliveryToRecipient" : 
+                    return EvidenceTypeInstance.DELIVERY_NON_DELIVERY_TO_RECIPIENT;
+                case "RelayREMMDAcceptanceRejection" :
+                    return EvidenceTypeInstance.RELAY_REM_MD_ACCEPTANCE_REJECTION;
+                default:
+                    return null;
+             }
+        } catch (NullPointerException npe) {
+            return null;
+        }
+    }
+    
+    public String getEvidenceIdentifier() {
+        return e().getEvidenceIdentifier();
+    }
+    
     public EventCode getEventCode() {
         return EventCode.valueFor(e().getEventCode());
     }
@@ -119,6 +139,10 @@ public class SignedRemEvidence {
         DocumentTypeIdentifier documentTypeIdentifier = new DocumentTypeIdentifier(messageSubject);
 
         return documentTypeIdentifier;
+    }
+    
+    public String getDocumentTypeInstanceIdentifier() {
+        return e().getSenderMessageDetails().getUAMessageIdentifier();
     }
 
     public InstanceIdentifier getInstanceIdentifier() {

--- a/peppol-evidence/src/test/java/no/difi/vefa/peppol/evidence/rem/RemEvidenceBuilderTest.java
+++ b/peppol-evidence/src/test/java/no/difi/vefa/peppol/evidence/rem/RemEvidenceBuilderTest.java
@@ -58,6 +58,7 @@ public class RemEvidenceBuilderTest {
                 .senderIdentifier(TestResources.SENDER_IDENTIFIER)
                 .recipientIdentifer(TestResources.RECIPIENT_IDENTIFIER)
                 .documentTypeId(TestResources.DOC_TYPE_ID)
+                .documentTypeInstanceIdentifier(TestResources.DOC_TYPE_INSTANCE_ID)
                 .instanceIdentifier(TestResources.INSTANCE_IDENTIFIER)
                 .payloadDigest("ThisIsASHA256Digest".getBytes())
                 .protocolSpecificEvidence(TransmissionRole.C_3, TransportProtocol.AS2, specificReceiptBytes)
@@ -120,8 +121,8 @@ public class RemEvidenceBuilderTest {
         DocumentTypeIdentifier documentTypeIdentifier = signedRemEvidence.getDocumentTypeIdentifier();
         assertNotNull(documentTypeIdentifier);
 
-        InstanceIdentifier instanceIdentifier = signedRemEvidence.getInstanceIdentifier();
-        assertNotNull(instanceIdentifier);
+        String documentTypeInstanceId = signedRemEvidence.getDocumentTypeInstanceIdentifier();
+        assertEquals(documentTypeInstanceId, TestResources.DOC_TYPE_INSTANCE_ID);
 
         byte[] digestBytes = signedRemEvidence.getPayloadDigestValue();
         assertNotNull(digestBytes);
@@ -213,5 +214,29 @@ public class RemEvidenceBuilderTest {
         
         assertNull(extensions);
     }
-    
+
+    @Test
+    public void testOptionalDocumentTypeInstanceId() throws Exception {
+
+        RemEvidenceBuilder builder = remEvidenceService.createDeliveryNonDeliveryToRecipientBuilder();
+        builder.eventCode(EventCode.ACCEPTANCE)
+                .eventTime(new Date())
+                .eventReason(EventReason.OTHER)
+                .evidenceIssuerPolicyID(TestResources.EVIDENCE_ISSUER_POLICY_ID)
+                .evidenceIssuerDetails(TestResources.EVIDENCE_ISSUER_NAME)
+                .senderIdentifier(TestResources.SENDER_IDENTIFIER)
+                .recipientIdentifer(TestResources.RECIPIENT_IDENTIFIER)
+                .documentTypeId(TestResources.DOC_TYPE_ID)
+                .instanceIdentifier(TestResources.INSTANCE_IDENTIFIER)
+                .payloadDigest("ThisIsASHA256Digest".getBytes())
+                .protocolSpecificEvidence(TransmissionRole.C_3, TransportProtocol.AS2, specificReceiptBytes)
+        ;
+
+
+        // Signs and builds the REMEvidenceType instance
+        SignedRemEvidence signedRemEvidence = builder.buildRemEvidenceInstance(privateKeyEntry);
+        
+        assertNull(signedRemEvidence.getDocumentTypeInstanceIdentifier());
+        
+    }    
 }

--- a/peppol-evidence/src/test/java/no/difi/vefa/peppol/evidence/rem/RemEvidenceServiceTest.java
+++ b/peppol-evidence/src/test/java/no/difi/vefa/peppol/evidence/rem/RemEvidenceServiceTest.java
@@ -5,20 +5,65 @@ import java.security.KeyStore;
 import no.difi.vefa.peppol.common.model.TransportProtocol;
 import no.difi.vefa.peppol.security.xmldsig.XmldsigVerifier;
 import static org.junit.Assert.assertNotNull;
+import static org.testng.Assert.assertEquals;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
  * Created by steinar on 08.11.2015.
  */
 public class RemEvidenceServiceTest {
+    
+    protected byte[] specificReceiptBytes;
+    protected KeyStore.PrivateKeyEntry privateKeyEntry;
+    
+
+    @BeforeClass
+    public void setUp() {
+        // Provides sample AS2 MDN to be included as evidence in the REM
+        specificReceiptBytes = TestResources.getSampleMdnSmime();
+
+        // Grabs our private key and certificate to be used for signing the REM
+        privateKeyEntry = TestResources.getPrivateKey();
+    }
 
 
     @Test
-    public void testCreaterelayRemMdAcceptanceRejectionBuilder() throws Exception {
+    public void testCreateDeliveryNonDeliveryToRecipientBuilder() throws Exception {
 
         RemEvidenceService remEvidenceService = new RemEvidenceService();
 
         RemEvidenceBuilder builder = remEvidenceService.createDeliveryNonDeliveryToRecipientBuilder();
+
+        byte[] sampleMdnSmime = TestResources.getSampleMdnSmime();
+
+        builder.eventCode(EventCode.ACCEPTANCE)
+                .evidenceIssuerPolicyID(TestResources.EVIDENCE_ISSUER_POLICY_ID)
+                .evidenceIssuerDetails(TestResources.EVIDENCE_ISSUER_NAME)
+                .senderIdentifier(TestResources.SENDER_IDENTIFIER)
+                .recipientIdentifer(TestResources.RECIPIENT_IDENTIFIER)
+                .documentTypeId(TestResources.DOC_TYPE_ID)
+                .instanceIdentifier(TestResources.INSTANCE_IDENTIFIER)
+                .payloadDigest("ThisIsASHA256Digest".getBytes())
+                .protocolSpecificEvidence(TransmissionRole.C_3, TransportProtocol.AS2, specificReceiptBytes);
+
+        ;
+
+        // Signs and builds the REMEvidenceType instance
+        SignedRemEvidence signedRemEvidence = builder.buildRemEvidenceInstance(privateKeyEntry);
+
+        assertNotNull(signedRemEvidence);
+        assertEquals(signedRemEvidence.getEvidenceType(), EvidenceTypeInstance.DELIVERY_NON_DELIVERY_TO_RECIPIENT);
+        
+        XmldsigVerifier.verify(signedRemEvidence.getDocument());
+    }
+    
+    @Test
+    public void testCreateRelayRemMdAcceptanceRejectionBuilder() throws Exception {
+
+        RemEvidenceService remEvidenceService = new RemEvidenceService();
+
+        RemEvidenceBuilder builder = remEvidenceService.createRelayRemMdAcceptanceRejectionBuilder();
 
         byte[] sampleMdnSmime = TestResources.getSampleMdnSmime();
         KeyStore.PrivateKeyEntry privateKey = TestResources.getPrivateKey();
@@ -39,7 +84,8 @@ public class RemEvidenceServiceTest {
         SignedRemEvidence signedRemEvidence = builder.buildRemEvidenceInstance(privateKey);
 
         assertNotNull(signedRemEvidence);
+        assertEquals(signedRemEvidence.getEvidenceType(), EvidenceTypeInstance.RELAY_REM_MD_ACCEPTANCE_REJECTION);
 
         XmldsigVerifier.verify(signedRemEvidence.getDocument());
-    }
+    }    
 }

--- a/peppol-evidence/src/test/java/no/difi/vefa/peppol/evidence/rem/TestResources.java
+++ b/peppol-evidence/src/test/java/no/difi/vefa/peppol/evidence/rem/TestResources.java
@@ -22,6 +22,7 @@ import static org.testng.Assert.assertNotNull;
 public class TestResources {
 
     public static final DocumentTypeIdentifier DOC_TYPE_ID = new DocumentTypeIdentifier("urn:oasis:names:specification:ubl:schema:xsd:Tender-2::Tender##urn:www.cenbii.eu:transaction:biitrdm090:ver3.0::2.1");
+    public static final String DOC_TYPE_INSTANCE_ID = "doc-type-instance-id";
     public static final InstanceIdentifier INSTANCE_IDENTIFIER = InstanceIdentifier.generateUUID();
     public static final ParticipantIdentifier SENDER_IDENTIFIER = new ParticipantIdentifier("9908:810017902");
     public static final ParticipantIdentifier RECIPIENT_IDENTIFIER = new ParticipantIdentifier("9908:123456789");


### PR DESCRIPTION
This pull request adds the option to include the _DocumentTypeInstanceIdentifier_ as the `uaMessageIdentifier` element (fix for issue #17) and get the evidence type from the `SignedRemEvidence` as enumeration value.
Also fixes an inconsistency in the `RemEvidenceServiceTest` class.