### PR TITLE
changed the getRemEvidenceType and getDocument methods to public

### DIFF
--- a/peppol-evidence/src/main/java/no/difi/vefa/peppol/evidence/rem/SignedRemEvidence.java
+++ b/peppol-evidence/src/main/java/no/difi/vefa/peppol/evidence/rem/SignedRemEvidence.java
@@ -39,11 +39,11 @@ public class SignedRemEvidence {
      *
      * @return
      */
-    protected REMEvidenceType getRemEvidenceType() {
+    public REMEvidenceType getRemEvidenceType() {
         return e();
     }
 
-    protected Document getDocument() {
+    public Document getDocument() {
         return signedRemEvidenceXml;
     }
 


### PR DESCRIPTION
Implementations like the Evidence Emitter SBB interfaces require to
return evidences as W3C Document files.