### PR TITLE
Granular exception handling for SML/SMP lookup failures

### DIFF
--- a/peppol-lookup/src/main/java/network/oxalis/vefa/peppol/lookup/LookupClient.java
+++ b/peppol-lookup/src/main/java/network/oxalis/vefa/peppol/lookup/LookupClient.java
@@ -29,7 +29,6 @@ import network.oxalis.vefa.peppol.security.api.CertificateValidator;
 import network.oxalis.vefa.peppol.security.lang.PeppolSecurityException;
 
 import javax.security.auth.x500.X500Principal;
-import java.io.FileNotFoundException;
 import java.net.URI;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -52,17 +51,13 @@ public class LookupClient {
         this.validator = builder.certificateValidator;
     }
 
-    public List<ServiceReference> getServiceReferences(ParticipantIdentifier participantIdentifier)
-            throws LookupException {
+    public List<ServiceReference> getServiceReferences(ParticipantIdentifier participantIdentifier) throws LookupException {
         URI location = locator.lookup(participantIdentifier);
         List<URI> serviceReferencesUriList = this.provider.resolveDocumentIdentifiers(location, participantIdentifier);
 
         FetcherResponse fetcherResponse;
-        try {
-            fetcherResponse = fetcher.fetch(serviceReferencesUriList);
-        } catch (FileNotFoundException e) {
-            throw new LookupException(String.format("Receiver (%s) not found.", participantIdentifier.toString()), e);
-        }
+
+        fetcherResponse = fetcher.fetch(serviceReferencesUriList);
 
         return reader.parseServiceGroup(fetcherResponse);
     }
@@ -140,9 +135,8 @@ public class LookupClient {
         try {
             FetcherResponse fetcherResponse = fetcher.fetch(serviceMetaDataUriList);
             return reader.parseServiceMetadata(fetcherResponse);
-        } catch (FileNotFoundException e) {
-            throw new LookupException(String.format(
-                    "Combination of receiver (%s) and document type identifier (%s) is not supported.",
+        } catch (PeppolResourceException e) {
+            throw new PeppolResourceException(String.format("Combination of receiver (%s) and document type identifier (%s) is not supported.",
                     participantIdentifier.toString(), documentTypeIdentifier.toString()), e);
         }
     }
@@ -160,8 +154,7 @@ public class LookupClient {
             return endpoint;
         }
 
-        throw new EndpointNotFoundException(
-                String.format("Combination of '%s' and transport profile(s) not found.", processIdentifier));
+        throw new EndpointNotFoundException(String.format("Combination of '%s' and transport profile(s) not found.", processIdentifier));
     }
 
     public Endpoint getEndpoint(ParticipantIdentifier participantIdentifier,

--- a/peppol-lookup/src/main/java/network/oxalis/vefa/peppol/lookup/api/FetcherResponse.java
+++ b/peppol-lookup/src/main/java/network/oxalis/vefa/peppol/lookup/api/FetcherResponse.java
@@ -19,8 +19,11 @@
 
 package network.oxalis.vefa.peppol.lookup.api;
 
+import lombok.Builder;
+
 import java.io.InputStream;
 
+@Builder
 public class FetcherResponse {
 
     private InputStream inputStream;

--- a/peppol-lookup/src/main/java/network/oxalis/vefa/peppol/lookup/api/MetadataFetcher.java
+++ b/peppol-lookup/src/main/java/network/oxalis/vefa/peppol/lookup/api/MetadataFetcher.java
@@ -20,12 +20,11 @@
 package network.oxalis.vefa.peppol.lookup.api;
 
 
-import java.io.FileNotFoundException;
 import java.net.URI;
 import java.util.List;
 
 public interface MetadataFetcher {
 
-    FetcherResponse fetch(List<URI> uriList) throws LookupException, FileNotFoundException;
+    FetcherResponse fetch(List<URI> uriList) throws LookupException;
 
 }

--- a/peppol-lookup/src/main/java/network/oxalis/vefa/peppol/lookup/api/NetworkFailureException.java
+++ b/peppol-lookup/src/main/java/network/oxalis/vefa/peppol/lookup/api/NetworkFailureException.java
@@ -1,0 +1,31 @@
+package network.oxalis.vefa.peppol.lookup.api;
+
+/**
+ * Low-level network I/O failure where the fault originates from transient network issues.
+ * Either in PEPPOL infrastructure or in the operator's own network, but we cannot determine which.
+ *
+ * <p>This is distinct from {@link PeppolInfrastructureException} — when we
+ * receive a definitive response from PEPPOL services (e.g., HTTP 5xx, DNS TRY_AGAIN),
+ * we know the infrastructure is at fault. {@code NetworkFailureException} is for
+ * cases where we never got a response at all.</p>
+ *
+ * <p><b>Operator action:</b> Retry. If persistent, check YOUR network first.</p>
+ *
+ * <p>Usage:</p>
+ * <ul>
+ *   <li>SocketTimeoutException — connection or read timed out</li>
+ *   <li>SocketException / connection reset — transport-level failure</li>
+ *   <li>General IOException with no diagnostic info</li>
+ * </ul>
+ */
+public class NetworkFailureException extends LookupException {
+
+    public NetworkFailureException(String message) {
+        super(message);
+    }
+
+    public NetworkFailureException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}
+

--- a/peppol-lookup/src/main/java/network/oxalis/vefa/peppol/lookup/api/PeppolInfrastructureException.java
+++ b/peppol-lookup/src/main/java/network/oxalis/vefa/peppol/lookup/api/PeppolInfrastructureException.java
@@ -1,0 +1,27 @@
+package network.oxalis.vefa.peppol.lookup.api;
+
+/**
+ * PEPPOL infrastructure (SML, SMP, or AP) is not functioning correctly or responding.
+ * The requested resource MAY exist, but we cannot confirm it due to service issues
+ * on the infrastructure side.
+ *
+ * <p>Usage:</p>
+ * <ul>
+ *   <li>SMP returned HTTP 5xx (server error)</li>
+ *   <li>SMP rate limiting (HTTP 429)</li>
+ *   <li>SML DNS returned TRY_AGAIN (transient DNS failure on PEPPOL infrastructure)</li>
+ *   <li>DNS resolution failure for SML/SMP hostnames (UnknownHostException) —
+ *       since SML operates via DNS, resolution failure indicates PEPPOL infrastructure problems</li>
+ * </ul>
+ */
+public class PeppolInfrastructureException extends LookupException {
+
+    public PeppolInfrastructureException(String message) {
+        super(message);
+    }
+
+    public PeppolInfrastructureException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}
+

--- a/peppol-lookup/src/main/java/network/oxalis/vefa/peppol/lookup/api/PeppolResourceException.java
+++ b/peppol-lookup/src/main/java/network/oxalis/vefa/peppol/lookup/api/PeppolResourceException.java
@@ -1,0 +1,25 @@
+package network.oxalis.vefa.peppol.lookup.api;
+
+/**
+ * A requested PEPPOL resource does not exist.
+ * This represents a SUCCESSFUL lookup with a definitive "no" answer —
+ * the lookup infrastructure worked correctly, the resource simply isn't there.
+ *
+ * <p>Usage:</p>
+ * <ul>
+ *   <li>Participant not registered in SML</li>
+ *   <li>Document type not supported by recipient</li>
+ *   <li>Endpoint not found for process/transport profile combination</li>
+ * </ul>
+ */
+public class PeppolResourceException extends LookupException {
+
+    public PeppolResourceException(String message) {
+        super(message);
+    }
+
+    public PeppolResourceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}
+

--- a/peppol-lookup/src/main/java/network/oxalis/vefa/peppol/lookup/fetcher/ApacheFetcher.java
+++ b/peppol-lookup/src/main/java/network/oxalis/vefa/peppol/lookup/fetcher/ApacheFetcher.java
@@ -20,8 +20,8 @@
 package network.oxalis.vefa.peppol.lookup.fetcher;
 
 import com.google.common.io.ByteStreams;
-import network.oxalis.vefa.peppol.lookup.api.FetcherResponse;
-import network.oxalis.vefa.peppol.lookup.api.LookupException;
+import lombok.extern.slf4j.Slf4j;
+import network.oxalis.vefa.peppol.lookup.api.*;
 import network.oxalis.vefa.peppol.mode.Mode;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
@@ -30,15 +30,43 @@ import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 
 import java.io.ByteArrayInputStream;
-import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.UnknownHostException;
 import java.util.List;
 
-public class ApacheFetcher extends BasicApacheFetcher {
+/**
+ * HTTP-based metadata fetcher using Apache HttpClient 5 with connection pooling.
+ *
+ * <p>Fetches SMP metadata from one or more URIs, trying each in order until one succeeds.
+ * Maps HTTP response codes and network errors to specific exception subtypes so that
+ * operators can make informed retry vs fallback decisions.</p>
+ *
+ * <p>Exception mapping at this (HTTP/SMP) layer:</p>
+ * <ul>
+ *   <li>HTTP 404 → {@link PeppolResourceException} — resource definitively not found</li>
+ *   <li>HTTP 429/5xx → {@link PeppolInfrastructureException} — SMP server issue, retry may help</li>
+ *   <li>Timeout/socket/DNS errors → {@link NetworkFailureException} — transport-level failure</li>
+ *   <li>Other HTTP codes → {@link LookupException} — unclassified, logged for investigation</li>
+ * </ul>
+ *
+ * <p><b>Design note on {@link UnknownHostException}:</b> at this HTTP layer, a DNS resolution
+ * failure is ambiguous — it could be a local resolver issue or the SMP host being unreachable.
+ * This is distinct from the SML/DNS layer ({@link network.oxalis.vefa.peppol.lookup.locator.BdxlLocator}),
+ * where DNS is the native protocol and result codes carry definitive meaning.
+ * See {@link NetworkFailureException} for the rationale.</p>
+ *
+ * @see PeppolResourceException
+ * @see PeppolInfrastructureException
+ * @see NetworkFailureException
+ */
+@Slf4j
+public class ApacheFetcher extends BasicApacheFetcher implements AutoCloseable {
 
+    private volatile CloseableHttpClient httpClient;
     private final PoolingHttpClientConnectionManager httpClientConnectionManager;
 
     public ApacheFetcher(Mode mode) {
@@ -54,62 +82,154 @@ public class ApacheFetcher extends BasicApacheFetcher {
                 .build();
     }
 
-    public FetcherResponse fetch(List<URI> uriList) throws LookupException, FileNotFoundException {
-        FetcherResponse fetcherResponse = null;
-        Exception exceptionObj = null;
+
+    /**
+     * Returns the shared HTTP client, creating it lazily on first use.
+     *
+     * <p>Lazy initialization avoids calling the virtual method {@link #createClient()}
+     * from the constructor, which breaks subclasses (OxalisApacheFetcher) that depends on post-construction
+     * field initialization</p>
+     */
+    protected CloseableHttpClient getHttpClient() {
+        if (httpClient == null) {
+            synchronized (this) {
+                if (httpClient == null) {
+                    httpClient = createClient();
+                }
+            }
+        }
+        return httpClient;
+    }
+
+    /**
+     * Attempts to fetch metadata from each URI in order, returning the first successful response.
+     * If all URIs fail, the last exception is re-thrown — preserving its specific subtype
+     * so the caller knows whether to retry or fall back.
+     *
+     * @param uriList one or more SMP metadata URIs to try in order
+     * @return the fetched metadata response from the first successful URI
+     * @throws PeppolResourceException       if the resource was definitively not found (HTTP 404)
+     * @throws PeppolInfrastructureException if the SMP server returned an error (HTTP 429/5xx)
+     * @throws NetworkFailureException       if a transport-level failure occurred (timeout, socket, DNS)
+     * @throws LookupException               if the URI list is null or an unclassified error occurred
+     */
+    public FetcherResponse fetch(List<URI> uriList) throws LookupException {
 
         if (uriList == null)
-            throw new LookupException("Unable to lookup requested url");
+            throw new LookupException("Provided URI list is null. Cannot perform metadata lookup.");
+
+        LookupException lastException = null;
 
         for (URI uri : uriList) {
             try {
-                fetcherResponse = fetchResponseFromValidUri(uri);
+                FetcherResponse fetcherResponse = fetchResponseFromValidUri(uri);
                 if (fetcherResponse != null) {
-                    exceptionObj = null;
-                    break;
+                    return fetcherResponse;
                 }
-            } catch (FileNotFoundException | LookupException e) {
-                exceptionObj = e;
+            } catch (LookupException e) {
+                log.debug("Error fetching metadata from URI: {}. Exception: {}", uri, e.getMessage());
+                lastException = e;
             }
         }
 
-        if (exceptionObj instanceof FileNotFoundException) {
-            throw new FileNotFoundException();
-        }
+        throw (lastException != null) ? lastException : new LookupException("Could not fetch metadata from any of the provided URIs.");
 
-        if (exceptionObj instanceof LookupException) {
-            throw new LookupException(exceptionObj.getMessage(), exceptionObj);
-        }
-
-        return fetcherResponse;
     }
 
-    private FetcherResponse fetchResponseFromValidUri(URI uri) throws LookupException, FileNotFoundException {
-        try (CloseableHttpClient httpClient = createClient()) {
-            HttpGet httpGet = new HttpGet(uri);
+    /**
+     * Fetches metadata from a single URI, mapping HTTP status codes and low-level
+     * network exceptions to the appropriate domain-specific subtypes.
+     *
+     * @throws PeppolResourceException       for HTTP 404 — participant/doc type not found at SMP
+     * @throws PeppolInfrastructureException for HTTP 429 (rate limit) and 5xx (server failures)
+     * @throws NetworkFailureException       for timeouts, connection resets, and DNS resolution failures
+     * @throws LookupException               for any other I/O error
+     */
+    private FetcherResponse fetchResponseFromValidUri(URI uri) throws LookupException {
 
-            try (CloseableHttpResponse response = httpClient.execute(httpGet)) {
-                int statusCode = response.getCode();
-                switch (statusCode) {
-                    case 200:
-                        return new FetcherResponse(
-                                new ByteArrayInputStream(ByteStreams.toByteArray(response.getEntity().getContent())),
-                                response.containsHeader("X-SMP-Namespace") ?
-                                        response.getFirstHeader("X-SMP-Namespace").getValue() : null
-                        );
-                    case 404:
-                        throw new FileNotFoundException(uri.toString());
-                    default:
-                        throw new LookupException(String.format(
-                                "Received code %s for lookup. URI: %s", statusCode, uri));
-                }
-            }
-        } catch (SocketTimeoutException | SocketException | UnknownHostException e) {
-            throw new LookupException(String.format("Unable to fetch '%s'", uri), e);
-        } catch (LookupException | FileNotFoundException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new LookupException(e.getMessage(), e);
+        HttpGet httpGet = new HttpGet(uri);
+
+        try (CloseableHttpResponse response = (CloseableHttpResponse) getHttpClient().executeOpen(null, httpGet, null)) {
+            // handle the response based on the status code and content
+            return handleResponse(uri, response);
+        } catch (SocketTimeoutException e) {
+            throw new NetworkFailureException("Connection timed out while fetching metadata from URI: " + uri, e);
+        } catch (SocketException e) {
+            throw new NetworkFailureException("Socket error while fetching metadata from URI: " + uri, e);
+        } catch (UnknownHostException e) {
+            throw new NetworkFailureException("SMP not found or cannot be resolved while fetching metadata from URI: " + uri, e);
+        } catch (IOException e) {
+            throw new LookupException("I/O error while fetching metadata from URI: " + uri, e);
+        }
+    }
+
+    /**
+     * Maps HTTP status codes to domain-specific exception types.
+     *
+     * @throws PeppolResourceException       for HTTP 404 — participant/doc type not found at SMP
+     * @throws PeppolInfrastructureException for HTTP 429 (rate limit) and 5xx (server failures)
+     * @throws LookupException               for any other unexpected HTTP status code
+     */
+    private static FetcherResponse handleResponse(URI uri, CloseableHttpResponse response) throws LookupException {
+        int statusCode = response.getCode();
+        switch (statusCode) {
+            // Successful response, transform it into FetcherResponse
+            case 200:
+                return transformResponse(response, uri);
+
+            // SMP Metadata not found, throw resource exception
+            case 404:
+                throw new PeppolResourceException("Participant metadata not found at URI: " + uri);
+
+                // Hitting SMP rate limit
+            case 429:
+                throw new PeppolInfrastructureException("Too many requests to SMP server at URI: " + uri + ". Please retry after some time.");
+
+                // server-side failures => PEPPOL infrastructure issues, throw infrastructure exception
+            case 500:
+            case 502:
+            case 503:
+            case 504:
+                throw new PeppolInfrastructureException("SMP server error (HTTP " + statusCode + ") while fetching metadata from URI: " + uri);
+
+            default:
+                throw new LookupException(String.format("Received HTTP status code %s for lookup at URI: %s", statusCode, uri));
+        }
+    }
+
+
+    /**
+     * Transforms a successful HTTP response into a {@link FetcherResponse},
+     * extracting the body content and the optional {@code X-SMP-Namespace} header.
+     */
+    private static FetcherResponse transformResponse(CloseableHttpResponse response, URI uri) throws LookupException {
+
+        if (response.getEntity() == null) {
+            throw new LookupException("Received empty response for metadata lookup at URI: " + uri);
+        }
+
+        try (InputStream inputStream = response.getEntity().getContent()) {
+            return FetcherResponse.builder()
+                    .inputStream(new ByteArrayInputStream(ByteStreams.toByteArray(inputStream)))
+                    .namespace(response.containsHeader("X-SMP-Namespace") ?
+                            response.getFirstHeader("X-SMP-Namespace").getValue() :
+                            null
+                    ).build();
+        } catch (IOException e) {
+            throw new LookupException("Error reading response content for metadata lookup at URI: " + uri, e);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        // synchronize to ensure thread safety when closing the shared HTTP client and connection manager
+        // because connection manager is shared.
+        synchronized (this) {
+            // close http client if it was created
+            if (httpClient != null) httpClient.close();
+
+            // close the connection manager to release all resources
+            httpClientConnectionManager.close();
         }
     }
 }

--- a/peppol-lookup/src/main/java/network/oxalis/vefa/peppol/lookup/fetcher/BasicApacheFetcher.java
+++ b/peppol-lookup/src/main/java/network/oxalis/vefa/peppol/lookup/fetcher/BasicApacheFetcher.java
@@ -25,7 +25,6 @@ import network.oxalis.vefa.peppol.mode.Mode;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.core5.util.Timeout;
 
-import java.io.FileNotFoundException;
 import java.net.URI;
 import java.util.List;
 
@@ -33,7 +32,7 @@ public abstract class BasicApacheFetcher extends AbstractFetcher {
 
     protected RequestConfig requestConfig;
 
-    public BasicApacheFetcher(Mode mode) {
+    protected BasicApacheFetcher(Mode mode) {
         super(mode);
 
         this.requestConfig = RequestConfig.custom()
@@ -43,6 +42,6 @@ public abstract class BasicApacheFetcher extends AbstractFetcher {
                 .build();
     }
 
-    public abstract FetcherResponse fetch(List<URI> uriList) throws LookupException, FileNotFoundException;
+    public abstract FetcherResponse fetch(List<URI> uriList) throws LookupException;
 
 }

--- a/peppol-lookup/src/main/java/network/oxalis/vefa/peppol/lookup/fetcher/UrlFetcher.java
+++ b/peppol-lookup/src/main/java/network/oxalis/vefa/peppol/lookup/fetcher/UrlFetcher.java
@@ -19,19 +19,16 @@
 
 package network.oxalis.vefa.peppol.lookup.fetcher;
 
-import network.oxalis.vefa.peppol.lookup.api.FetcherResponse;
-import network.oxalis.vefa.peppol.lookup.api.LookupException;
+import lombok.extern.slf4j.Slf4j;
+import network.oxalis.vefa.peppol.lookup.api.*;
 import network.oxalis.vefa.peppol.mode.Mode;
 
 import java.io.BufferedInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.SocketException;
-import java.net.SocketTimeoutException;
-import java.net.URI;
+import java.net.*;
 import java.util.List;
 
+@Slf4j
 public class UrlFetcher extends AbstractFetcher {
 
     public UrlFetcher(Mode mode) {
@@ -39,54 +36,71 @@ public class UrlFetcher extends AbstractFetcher {
     }
 
     @Override
-    public FetcherResponse fetch(List<URI> uriList) throws LookupException, FileNotFoundException {
-        FetcherResponse fetcherResponse = null;
-        Exception exceptionObj = null;
+    public FetcherResponse fetch(List<URI> uriList) throws LookupException {
 
         if (uriList == null)
-            throw new LookupException("Unable to lookup requested url");
+            throw new LookupException("Provided URI list is null. Cannot perform metadata lookup.");
+
+        LookupException lastException = null;
 
         for (URI uri : uriList) {
             try {
-                fetcherResponse = fetchResponseFromValidUri(uri);
+                FetcherResponse fetcherResponse = fetchResponseFromValidUri(uri);
                 if (fetcherResponse != null) {
-                    exceptionObj = null;
-                    break;
+                    return fetcherResponse;
                 }
-            } catch (FileNotFoundException | LookupException e) {
-                exceptionObj = e;
+            } catch (LookupException e) {
+                log.debug("Error fetching metadata from URI: {}. Exception: {}", uri, e.getMessage());
+                lastException = e;
             }
         }
 
-        if (exceptionObj instanceof FileNotFoundException) {
-            throw new FileNotFoundException();
-        }
-
-        if (exceptionObj instanceof LookupException) {
-            throw new LookupException(exceptionObj.getMessage(), exceptionObj);
-        }
-
-        return fetcherResponse;
+        throw (lastException != null) ? lastException
+                : new LookupException("Could not fetch metadata from any of the provided URIs.");
     }
 
-    private FetcherResponse fetchResponseFromValidUri(URI uri) throws LookupException, FileNotFoundException {
+    private FetcherResponse fetchResponseFromValidUri(URI uri) throws LookupException {
         try {
-            HttpURLConnection urlConnection = getHttpURLConnection(uri);
-            if (urlConnection.getResponseCode() != 200) {
-                return null;
-            }
-
-            return new FetcherResponse(
-                    new BufferedInputStream(urlConnection.getInputStream()),
-                    urlConnection.getHeaderField("X-SMP-Namespace"));
-        } catch (FileNotFoundException e) {
-            throw new FileNotFoundException(uri.toString());
-        } catch (SocketTimeoutException | SocketException e) {
-            throw new LookupException(String.format("Unable to fetch '%s'", uri), e);
+            HttpURLConnection connection = getHttpURLConnection(uri);
+            return handleResponse(uri, connection);
+        } catch (SocketTimeoutException e) {
+            throw new NetworkFailureException("Connection timed out while fetching metadata from URI: " + uri, e);
+        } catch (SocketException e) {
+            throw new NetworkFailureException("Socket error while fetching metadata from URI: " + uri, e);
+        } catch (UnknownHostException e) {
+            throw new NetworkFailureException("SMP not found or cannot be resolved while fetching metadata from URI: " + uri, e);
         } catch (IOException e) {
-            throw new LookupException(e.getMessage(), e);
+            throw new LookupException("I/O error while fetching metadata from URI: " + uri, e);
         }
     }
+
+    private static FetcherResponse handleResponse(URI uri, HttpURLConnection connection) throws IOException, LookupException {
+        int statusCode = connection.getResponseCode();
+        switch (statusCode) {
+            case 200:
+                return new FetcherResponse(new BufferedInputStream(
+                        connection.getInputStream()),
+                        connection.getHeaderField("X-SMP-Namespace")
+                );
+
+            case 404:
+                throw new PeppolResourceException("Participant metadata not found at URI: " + uri);
+
+            case 429:
+                throw new PeppolInfrastructureException("Too many requests to SMP server at URI: " + uri + ". Please retry after some time.");
+
+
+            case 500:
+            case 502:
+            case 503:
+            case 504:
+                throw new PeppolInfrastructureException("SMP server error (HTTP " + statusCode + ") while fetching metadata from URI: " + uri);
+
+            default:
+                throw new LookupException(String.format("Received HTTP status code %s for lookup at URI: %s", statusCode, uri));
+        }
+    }
+
 
     private HttpURLConnection getHttpURLConnection(URI uri) throws IOException {
         HttpURLConnection urlConnection = (HttpURLConnection) uri.toURL().openConnection();

--- a/peppol-lookup/src/main/java/network/oxalis/vefa/peppol/lookup/locator/BdxlLocator.java
+++ b/peppol-lookup/src/main/java/network/oxalis/vefa/peppol/lookup/locator/BdxlLocator.java
@@ -20,20 +20,22 @@
 package network.oxalis.vefa.peppol.lookup.locator;
 
 import com.google.common.io.BaseEncoding;
+import lombok.extern.slf4j.Slf4j;
 import network.oxalis.vefa.peppol.common.model.ParticipantIdentifier;
 import network.oxalis.vefa.peppol.lookup.api.LookupException;
-import network.oxalis.vefa.peppol.lookup.api.NotFoundException;
+import network.oxalis.vefa.peppol.lookup.api.PeppolInfrastructureException;
+import network.oxalis.vefa.peppol.lookup.api.PeppolResourceException;
 import network.oxalis.vefa.peppol.lookup.util.DynamicHostnameGenerator;
 import network.oxalis.vefa.peppol.lookup.util.EncodingUtils;
 import network.oxalis.vefa.peppol.mode.Mode;
 import org.apache.commons.lang3.StringUtils;
-import org.xbill.DNS.Record;
-import org.xbill.DNS.NAPTRRecord;
 import org.xbill.DNS.ExtendedResolver;
-import org.xbill.DNS.SimpleResolver;
 import org.xbill.DNS.Lookup;
-import org.xbill.DNS.Type;
+import org.xbill.DNS.NAPTRRecord;
+import org.xbill.DNS.Record;
+import org.xbill.DNS.SimpleResolver;
 import org.xbill.DNS.TextParseException;
+import org.xbill.DNS.Type;
 
 import java.net.InetAddress;
 import java.net.URI;
@@ -48,7 +50,24 @@ import java.util.regex.Pattern;
  * Implementation of Business Document Metadata Service Location Version 1.0.
  *
  * @see <a href="http://docs.oasis-open.org/bdxr/BDX-Location/v1.0/BDX-Location-v1.0.html">Specification</a>
+ *
+ *
+ * <p>DNS result codes are mapped to domain-specific exceptions at this layer.
+ * Unlike the HTTP/SMP layer ({@link network.oxalis.vefa.peppol.lookup.fetcher.ApacheFetcher}),
+ * DNS is the native protocol here, so result codes carry definitive meaning:</p>
+ * <ul>
+ *   <li>HOST_NOT_FOUND / TYPE_NOT_FOUND → {@link PeppolResourceException}
+ *       — participant definitively not in SML</li>
+ *   <li>TRY_AGAIN → {@link PeppolInfrastructureException}
+ *       — transient DNS failure, retry may help</li>
+ *   <li>UNRECOVERABLE → {@link PeppolInfrastructureException}
+ *       — SML DNS server error</li>
+ * </ul>
+ * @see PeppolResourceException
+ * @see PeppolInfrastructureException
  */
+
+@Slf4j
 public class BdxlLocator extends AbstractLocator {
 
     private final long timeout;
@@ -120,8 +139,8 @@ public class BdxlLocator extends AbstractLocator {
      * @param prefix          Value attached in front of calculated hash.
      * @param hostname        Hostname used as base for lookup.
      * @param digestAlgorithm Algorithm used for generation of hostname.
-     * @param timeout Lookup timeout
-     * @param maxRetries Maximum number of retries
+     * @param timeout         Lookup timeout
+     * @param maxRetries      Maximum number of retries
      * @param enablePublicDNS Enable custom DNS lookup
      */
     public BdxlLocator(String prefix, String hostname, String digestAlgorithm, long timeout, int maxRetries, boolean enablePublicDNS) {
@@ -135,8 +154,8 @@ public class BdxlLocator extends AbstractLocator {
      * @param hostname        Hostname used as base for lookup.
      * @param digestAlgorithm Algorithm used for generation of hostname.
      * @param encoding        Encoding of hash for hostname.
-     * @param timeout Lookup timeout
-     * @param maxRetries Maximum number of retries
+     * @param timeout         Lookup timeout
+     * @param maxRetries      Maximum number of retries
      * @param enablePublicDNS Enable custom DNS lookup
      */
     public BdxlLocator(String prefix, String hostname, String digestAlgorithm, BaseEncoding encoding, long timeout, int maxRetries, boolean enablePublicDNS) {
@@ -146,86 +165,188 @@ public class BdxlLocator extends AbstractLocator {
         hostnameGenerator = new DynamicHostnameGenerator(prefix, hostname, digestAlgorithm, encoding);
     }
 
+    /**
+     * Resolves a participant identifier to an SMP URI via NAPTR DNS lookup against the SML.
+     * - Generates the lookup hostname from the participant identifier,
+     * - queries DNS for NAPTR records,
+     * - extracts the SMP endpoint URI from the matching record's regex field.
+     *
+     * @param participantIdentifier the participant to look up in SML
+     * @return the SMP URI for the participant
+     * @throws PeppolResourceException       if the participant is not registered in SML (HOST_NOT_FOUND / TYPE_NOT_FOUND)
+     * @throws PeppolInfrastructureException if SML DNS is not responding or returned a server error (TRY_AGAIN / UNRECOVERABLE)
+     * @throws LookupException               if an unexpected error occurred during lookup
+     */
     @Override
     public URI lookup(ParticipantIdentifier participantIdentifier) throws LookupException {
         // Create hostname for participant identifier.
         String hostname = hostnameGenerator.generate(participantIdentifier).replaceAll("=*", "");
 
+        ExtendedResolver extendedResolver = getExtendedResolver(hostname);
+
+        Record[] records = performLookupWithRetry(hostname, extendedResolver, participantIdentifier);
+
+        return extractSmpUriFromRecords(records, hostname);
+    }
+
+    /**
+     * Creates and configures a DNS resolver. When public DNS is enabled, uses Google and
+     * Cloudflare servers for resilience against local DNS issues. Otherwise falls back to
+     * the system's default resolver.
+     */
+    private ExtendedResolver getExtendedResolver(String hostname) {
         ExtendedResolver extendedResolver;
-        try {
-            if(enablePublicDNS) {
-                extendedResolver = CustomExtendedDNSResolver.createExtendedResolver(customDNSServers, timeout, maxRetries);
-            } else {
-                extendedResolver = new ExtendedResolver();
-                try {
-                    if (StringUtils.isNotBlank(hostname)) {
-                        extendedResolver.addResolver(new SimpleResolver(hostname));
-                    }
-                } catch (final UnknownHostException ex) {
-                    //Primary DNS lookup fail, now try with default resolver
+        if (enablePublicDNS) {
+            return CustomExtendedDNSResolver.createExtendedResolver(customDNSServers, timeout, maxRetries);
+        } else {
+            extendedResolver = new ExtendedResolver();
+            try {
+                if (StringUtils.isNotBlank(hostname)) {
+                    extendedResolver.addResolver(new SimpleResolver(hostname));
                 }
-                extendedResolver.addResolver (Lookup.getDefaultResolver ());
+            } catch (final UnknownHostException ex) {
+                //Primary DNS lookup fail, now try with default resolver
             }
-            extendedResolver.setRetries(maxRetries);
-            extendedResolver.setTimeout(Duration.ofSeconds(timeout));
+            extendedResolver.addResolver(Lookup.getDefaultResolver());
+        }
+        extendedResolver.setRetries(maxRetries);
+        extendedResolver.setTimeout(Duration.ofSeconds(timeout));
+        return extendedResolver;
+    }
 
-            // Fetch all records of type NAPTR registered on hostname.
-            final Lookup naptrLookup = new Lookup(hostname, Type.NAPTR);
-            naptrLookup.setResolver(extendedResolver);
 
-            Record[] records;
-            int retryCountLeft = maxRetries;
-            // Retry, the NAPTR lookup may fail due to a network error. Repeating the lookup might be helpful
-            do {
-                records = naptrLookup.run();
-                --retryCountLeft;
-            } while (naptrLookup.getResult() == Lookup.TRY_AGAIN && retryCountLeft >= 0);
+    /**
+     * Performs NAPTR DNS lookup with retry logic.
+     * Tries UDP first, then falls back to TCP if UDP retries are exhausted.
+     *
+     * @throws PeppolResourceException       If participant is definitively not registered in SML.
+     * @throws PeppolInfrastructureException If SML DNS is not responding or returned a server error.
+     */
+    private Record[] performLookupWithRetry(String hostname, ExtendedResolver extendedResolver, ParticipantIdentifier participantIdentifier)
+            throws LookupException {
 
-            // Retry with TCP as well
-            if (naptrLookup.getResult() == Lookup.TRY_AGAIN) {
-                extendedResolver.setTCP(true);
+        final Lookup naptrLookup = getLookup(hostname, extendedResolver);
 
-                retryCountLeft = maxRetries;
-                do {
-                    records = naptrLookup.run();
-                    --retryCountLeft;
-                } while (naptrLookup.getResult() == Lookup.TRY_AGAIN && retryCountLeft >= 0);
-            }
+        Record[] records = executeWithRetry(naptrLookup, maxRetries);
 
-            if (naptrLookup.getResult() != Lookup.SUCCESSFUL) {
-                switch (naptrLookup.getResult()) {
-                    case Lookup.HOST_NOT_FOUND: // The host does not exist
-                        throw new NotFoundException(String.format("Identifier '%s' is not registered in SML. The host '%s' does not exist", participantIdentifier.getIdentifier(), hostname));
-                    case Lookup.TYPE_NOT_FOUND: // The host exists, but has no records associated with the queried type
-                        throw new NotFoundException(String.format("Identifier '%s' is not registered in SML. The Host '%s' exists, but has no records associated with the queried type", participantIdentifier.getIdentifier(), hostname));
-                    case Lookup.TRY_AGAIN: // The lookup failed due to a network error. Repeating the lookup may be helpful.
-                        throw new LookupException(String.format("Error when looking up identifier '%s' in SML due to network error. Retry after sometime... DNS-Lookup-Err: %s", participantIdentifier.getIdentifier(), naptrLookup.getErrorString()));
-                    case Lookup.UNRECOVERABLE: // The lookup failed due to a data or server error. Repeating the lookup would not be helpful.
-                        throw new LookupException(String.format("Error when looking up identifier '%s' in SML due to a data or server error. Repeating the lookup immediately would not be helpful. DNS-Lookup-Err: %s", participantIdentifier.getIdentifier(), naptrLookup.getErrorString()));
-                    default:
-                        throw new LookupException(String.format("Error when looking up identifier '%s' in SML. DNS-Lookup-Err: %s", participantIdentifier.getIdentifier(), naptrLookup.getErrorString()));
-                }
-            }
-
-            // Loop records found.
-            for (Record record : records) {
-                // Simple cast.
-                NAPTRRecord naptrRecord = (NAPTRRecord) record;
-
-                // Handle only those having "Meta:SMP" as service.
-                if ("Meta:SMP".equals(naptrRecord.getService()) && "U".equalsIgnoreCase(naptrRecord.getFlags())) {
-
-                    // Create URI and return.
-                    String result = handleRegex(naptrRecord.getRegexp(), hostname);
-                    if (result != null)
-                        return URI.create(result);
-                }
-            }
-        } catch (TextParseException e) {
-            throw new LookupException("Error when handling DNS lookup for BDXL.", e);
+        // UDP exhausted retries with TRY_AGAIN, falling back to TCP
+        if (naptrLookup.getResult() == Lookup.TRY_AGAIN) {
+            log.debug("UDP DNS lookup exhausted retries for '{}', falling back to TCP", hostname);
+            extendedResolver.setTCP(true);
+            records = executeWithRetry(naptrLookup, maxRetries);
         }
 
-        throw new NotFoundException("Record for SMP not found in SML.");
+        if (naptrLookup.getResult() == Lookup.SUCCESSFUL) {
+            return records;
+        }
+
+        // Lookup failed — translate DNS result code to the appropriate domain-specific exception
+        handleLookupFailure(naptrLookup, participantIdentifier);
+
+        throw new LookupException("Unexpected state after DNS lookup for: " + hostname);
+    }
+
+    // factory method to create a Lookup object for NAPTR records
+    private static Lookup getLookup(String hostname, ExtendedResolver extendedResolver) throws LookupException {
+        try {
+            Lookup naptrLookup = new Lookup(hostname, Type.NAPTR);
+            naptrLookup.setResolver(extendedResolver);
+            return naptrLookup;
+        } catch (TextParseException e) {
+            throw new LookupException("Error when creating DNS lookup for hostname: " + hostname, e);
+        }
+    }
+
+    /**
+     * Executes a DNS lookup with the specified number of retries.
+     * Only retries on TRY_AGAIN results (transient DNS errors).
+     */
+    private Record[] executeWithRetry(Lookup lookup, int retries) {
+        Record[] records;
+        int retriesLeft = retries;
+        do {
+            records = lookup.run();
+            --retriesLeft;
+        } while (lookup.getResult() == Lookup.TRY_AGAIN && retriesLeft >= 0);
+        return records;
+    }
+
+    /**
+     * Extracts the SMP URI from NAPTR DNS records. Filters for records with
+     * service {@code "Meta:SMP"} and flag {@code "U"}, then applies the record's
+     * regex to derive the final SMP endpoint URI.
+     *
+     * @throws PeppolResourceException if no matching NAPTR record is found
+     */
+    private URI extractSmpUriFromRecords(Record[] records, String hostname) throws PeppolResourceException {
+        if (records == null) {
+            throw new PeppolResourceException("Record for SMP not found in SML.");
+        }
+
+        for (Record dnsRecord : records) {
+            // Guard against unexpected record types in the DNS response
+            if (!(dnsRecord instanceof NAPTRRecord)) {
+                continue;
+            }
+
+            NAPTRRecord naptrRecord = (NAPTRRecord) dnsRecord;
+
+            // Handle only those having "Meta:SMP" as service.
+            if ("Meta:SMP".equals(naptrRecord.getService()) && "U".equalsIgnoreCase(naptrRecord.getFlags())) {
+
+                // Create URI and return.
+                String result = handleRegex(naptrRecord.getRegexp(), hostname);
+                if (result != null)
+                    return URI.create(result);
+            }
+        }
+
+        throw new PeppolResourceException("Record for SMP not found in SML.");
+    }
+
+
+    /**
+     * Translates DNS lookup result codes into domain-specific exception types.
+     *
+     * <ul>
+     *   <li>HOST_NOT_FOUND, TYPE_NOT_FOUND → {@link PeppolResourceException}
+     *       (definitive — participant not currently registered in SML.
+     *        Retry after verifying the identifier or SMP registration details)</li>
+     *   <li>TRY_AGAIN → {@link PeppolInfrastructureException}
+     *       (transient — SML DNS not responding, retry may help)</li>
+     *   <li>UNRECOVERABLE → {@link PeppolInfrastructureException}
+     *       (SML DNS server error — retry unlikely to help immediately)</li>
+     * </ul>
+     */
+    private void handleLookupFailure(Lookup naptrLookup,
+                                     ParticipantIdentifier participantIdentifier) throws LookupException {
+        String identifier = participantIdentifier.getIdentifier();
+
+        switch (naptrLookup.getResult()) {
+            case Lookup.HOST_NOT_FOUND:
+                // Definitive: participant does not exist in SML
+                throw new PeppolResourceException(String.format("Participant with identifier '%s' is not registered in SML. " +
+                        "The host does not exist", identifier));
+
+            case Lookup.TYPE_NOT_FOUND:
+                // Definitive: host exists but no NAPTR records — not properly registered
+                throw new PeppolResourceException(String.format("Participant with identifier '%s' is not registered in SML. " +
+                        "The Host exists, but has no records associated with the queried type", identifier));
+
+            case Lookup.TRY_AGAIN:
+                // Transient: SML DNS infrastructure issue — retryable
+                throw new PeppolInfrastructureException(String.format("SML lookup failed for identifier '%s' due to network error. " +
+                        "Retry may help. DNS-Lookup-Err: %s", identifier, naptrLookup.getErrorString()));
+
+            case Lookup.UNRECOVERABLE:
+                // SML DNS server error — PEPPOL infrastructure fault
+                throw new PeppolInfrastructureException(String.format("SML lookup failed for identifier '%s' due to a data or server error. " +
+                        "Repeating the lookup immediately would not be helpful. DNS-Lookup-Err: %s", identifier, naptrLookup.getErrorString()));
+
+            default:
+                throw new LookupException(String.format("Error when looking up identifier '%s' in SML. DNS-Lookup-Err: %s",
+                        identifier, naptrLookup.getErrorString()));
+        }
     }
 
     public static String handleRegex(String naptrRegex, String hostname) {

--- a/peppol-lookup/src/main/java/network/oxalis/vefa/peppol/lookup/locator/BusdoxLocator.java
+++ b/peppol-lookup/src/main/java/network/oxalis/vefa/peppol/lookup/locator/BusdoxLocator.java
@@ -19,9 +19,11 @@
 
 package network.oxalis.vefa.peppol.lookup.locator;
 
+import lombok.extern.slf4j.Slf4j;
 import network.oxalis.vefa.peppol.common.model.ParticipantIdentifier;
 import network.oxalis.vefa.peppol.lookup.api.LookupException;
-import network.oxalis.vefa.peppol.lookup.api.NotFoundException;
+import network.oxalis.vefa.peppol.lookup.api.PeppolInfrastructureException;
+import network.oxalis.vefa.peppol.lookup.api.PeppolResourceException;
 import network.oxalis.vefa.peppol.lookup.util.DynamicHostnameGenerator;
 import network.oxalis.vefa.peppol.mode.Mode;
 import org.apache.commons.lang3.StringUtils;
@@ -37,6 +39,25 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Busdox SML locator — resolves a participant identifier to an SMP URI using A-record DNS lookups with MD5-based hostname generation.
+ *
+ * <p>DNS result codes are mapped to domain-specific exceptions at the SML/DNS layer,
+ * these codes carry definitive meaning:</p>
+ * <ul>
+ *   <li>HOST_NOT_FOUND / TYPE_NOT_FOUND → {@link PeppolResourceException}
+ *       — participant definitively not in SML</li>
+ *   <li>TRY_AGAIN → {@link PeppolInfrastructureException}
+ *       — transient DNS failure, retry may help</li>
+ *   <li>UNRECOVERABLE → {@link PeppolInfrastructureException}
+ *       — SML DNS server error</li>
+ * </ul>
+ *
+ * @see BdxlLocator
+ * @see PeppolResourceException
+ * @see PeppolInfrastructureException
+ */
+@Slf4j
 public class BusdoxLocator extends AbstractLocator {
 
     private final long timeout;
@@ -93,68 +114,148 @@ public class BusdoxLocator extends AbstractLocator {
         hostnameGenerator = new DynamicHostnameGenerator(prefix, hostname, algorithm);
     }
 
+    /**
+     * Resolves a participant identifier to an SMP URI via A-record DNS lookup against the SML.
+     * - Generates the lookup hostname from the participant identifier using MD5 hashing,
+     * - verifies the hostname resolves, and returns the SMP base URI.
+     *
+     * @param participantIdentifier the participant to look up in SML
+     * @return the SMP base URI for the participant (http://{generated-hostname})
+     * @throws PeppolResourceException       if the participant is not registered in SML (HOST_NOT_FOUND / TYPE_NOT_FOUND)
+     * @throws PeppolInfrastructureException if SML DNS is not responding or returned a server error (TRY_AGAIN / UNRECOVERABLE)
+     * @throws LookupException               if an unexpected error occurred during lookup
+     */
     @Override
     public URI lookup(ParticipantIdentifier participantIdentifier) throws LookupException {
         // Create hostname for participant identifier.
         String hostname = hostnameGenerator.generate(participantIdentifier);
 
-        ExtendedResolver extendedResolver;
-        try {
-            if(enablePublicDNS) {
-                extendedResolver = CustomExtendedDNSResolver.createExtendedResolver(customDNSServers, timeout, maxRetries);
-            } else {
-                extendedResolver = new ExtendedResolver();
-                try {
-                    if (StringUtils.isNotBlank(hostname)) {
-                        extendedResolver.addResolver(new SimpleResolver(hostname));
-                    }
-                } catch (final UnknownHostException ex) {
-                    //Primary DNS lookup fail, now try with default resolver
-                }
-                extendedResolver.addResolver (Lookup.getDefaultResolver ());
-            }
-            extendedResolver.setRetries(maxRetries);
-            extendedResolver.setTimeout(Duration.ofSeconds(timeout));
+        ExtendedResolver extendedResolver = getExtendedResolver(hostname);
 
-            final Lookup lookup = new Lookup(hostname);
-            lookup.setResolver(extendedResolver);
-
-            int retryCountLeft = maxRetries;
-            // Retry, The lookup may fail due to a network error. Repeating the lookup might be helpful
-            do {
-                lookup.run();
-                --retryCountLeft;
-            } while (lookup.getResult() == Lookup.TRY_AGAIN && retryCountLeft >= 0);
-
-            // Retry with TCP as well
-            if (lookup.getResult() == Lookup.TRY_AGAIN) {
-                extendedResolver.setTCP(true);
-
-                retryCountLeft = maxRetries;
-                do {
-                    lookup.run();
-                    --retryCountLeft;
-                } while (lookup.getResult() == Lookup.TRY_AGAIN && retryCountLeft >= 0);
-            }
-
-            if (lookup.getResult() != Lookup.SUCCESSFUL) {
-                switch (lookup.getResult()) {
-                    case Lookup.HOST_NOT_FOUND: // The host does not exist
-                        throw new NotFoundException(String.format("Identifier '%s' is not registered in SML. The host '%s' does not exist", participantIdentifier.getIdentifier(), hostname));
-                    case Lookup.TYPE_NOT_FOUND: // The host exists, but has no records associated with the queried type
-                        throw new NotFoundException(String.format("Identifier '%s' is not registered in SML. The Host '%s' exists, but has no records associated with the queried type", participantIdentifier.getIdentifier(), hostname));
-                    case Lookup.TRY_AGAIN: // The lookup failed due to a network error. Repeating the lookup may be helpful.
-                        throw new LookupException(String.format("Error when looking up identifier '%s' in SML due to network error. Retry after sometime... DNS-Lookup-Err: %s", participantIdentifier.getIdentifier(), lookup.getErrorString()));
-                    case Lookup.UNRECOVERABLE: // The lookup failed due to a data or server error. Repeating the lookup would not be helpful.
-                        throw new LookupException(String.format("Error when looking up identifier '%s' in SML due to a data or server error. Repeating the lookup immediately would not be helpful. DNS-Lookup-Err: %s", participantIdentifier.getIdentifier(), lookup.getErrorString()));
-                    default:
-                        throw new LookupException(String.format("Error when looking up identifier '%s' in SML. DNS-Lookup-Err: %s", participantIdentifier.getIdentifier(), lookup.getErrorString()));
-                }
-            }
-        } catch (TextParseException e) {
-            throw new LookupException(e.getMessage(), e);
-        }
+        performLookupWithRetry(hostname, extendedResolver, participantIdentifier);
 
         return URI.create(String.format("http://%s", hostname));
     }
+
+    /**
+     * Creates and configures a DNS resolver. When public DNS is enabled, uses Google and
+     * Cloudflare servers for resilience against local DNS issues. Otherwise falls back to
+     * the system's default resolver.
+     */
+    private ExtendedResolver getExtendedResolver(String hostname) {
+        ExtendedResolver extendedResolver;
+        if (enablePublicDNS) {
+            return CustomExtendedDNSResolver.createExtendedResolver(customDNSServers, timeout, maxRetries);
+        } else {
+            extendedResolver = new ExtendedResolver();
+            try {
+                if (StringUtils.isNotBlank(hostname)) {
+                    extendedResolver.addResolver(new SimpleResolver(hostname));
+                }
+            } catch (final UnknownHostException ex) {
+                //Primary DNS lookup fail, now try with default resolver
+            }
+            extendedResolver.addResolver(Lookup.getDefaultResolver());
+        }
+        extendedResolver.setRetries(maxRetries);
+        extendedResolver.setTimeout(Duration.ofSeconds(timeout));
+        return extendedResolver;
+    }
+
+
+    /**
+     * Performs DNS A-record lookup with retry logic.
+     * Tries UDP first, then falls back to TCP if UDP retries are exhausted.
+     *
+     * @throws PeppolResourceException       If participant is definitively not registered in SML.
+     * @throws PeppolInfrastructureException If SML DNS is not responding or returned a server error.
+     */
+    private void performLookupWithRetry(String hostname, ExtendedResolver extendedResolver, ParticipantIdentifier participantIdentifier)
+            throws LookupException {
+
+        final Lookup lookup = getLookup(hostname, extendedResolver);
+
+        executeWithRetry(lookup, maxRetries);
+
+        // UDP exhausted retries with TRY_AGAIN, falling back to TCP
+        if (lookup.getResult() == Lookup.TRY_AGAIN) {
+            log.debug("UDP DNS lookup exhausted retries for '{}', falling back to TCP", hostname);
+            extendedResolver.setTCP(true);
+            executeWithRetry(lookup, maxRetries);
+        }
+
+        if (lookup.getResult() == Lookup.SUCCESSFUL) {
+            return;
+        }
+
+        // Lookup failed — translate DNS result code to the appropriate domain-specific exception
+        handleLookupFailure(lookup, participantIdentifier);
+
+        throw new LookupException("Unexpected state after DNS lookup for: " + hostname);
+    }
+
+    // factory method to create a Lookup object for NAPTR records
+    private static Lookup getLookup(String hostname, ExtendedResolver extendedResolver) throws LookupException {
+        try {
+            Lookup lookup = new Lookup(hostname);
+            lookup.setResolver(extendedResolver);
+            return lookup;
+        } catch (TextParseException e) {
+            throw new LookupException("Error when creating DNS lookup for hostname: " + hostname, e);
+        }
+    }
+
+    /**
+     * Executes a DNS lookup with the specified number of retries.
+     * Only retries on TRY_AGAIN results (transient DNS errors).
+     */
+    private void executeWithRetry(Lookup lookup, int retries) {
+        int retriesLeft = retries;
+        do {
+            lookup.run();
+            --retriesLeft;
+        } while (lookup.getResult() == Lookup.TRY_AGAIN && retriesLeft >= 0);
+    }
+
+
+    /**
+     * Translates DNS lookup result codes into domain-specific exception types.
+     *
+     * <ul>
+     *   <li>HOST_NOT_FOUND, TYPE_NOT_FOUND → {@link PeppolResourceException}
+     *       (definitive — participant not currently registered in SML.
+     *        Retry after verifying the identifier or SMP registration details)</li>
+     *   <li>TRY_AGAIN → {@link PeppolInfrastructureException}
+     *       (transient — SML DNS not responding, retry may help)</li>
+     *   <li>UNRECOVERABLE → {@link PeppolInfrastructureException}
+     *       (SML DNS server error — retry unlikely to help immediately)</li>
+     * </ul>
+     */
+    private void handleLookupFailure(Lookup lookup,
+                                     ParticipantIdentifier participantIdentifier) throws LookupException {
+        String identifier = participantIdentifier.getIdentifier();
+
+        switch (lookup.getResult()) {
+            case Lookup.HOST_NOT_FOUND:
+                throw new PeppolResourceException(String.format("Participant with identifier '%s' is not registered in SML. " +
+                        "The host does not exist", identifier));
+
+            case Lookup.TYPE_NOT_FOUND:
+                throw new PeppolResourceException(String.format("Participant with identifier '%s' is not registered in SML. " +
+                        "The Host exists, but has no records associated with the queried type", identifier));
+
+            case Lookup.TRY_AGAIN:
+                throw new PeppolInfrastructureException(String.format("SML lookup failed for identifier '%s' due to network error. " +
+                        "Retry may help. DNS-Lookup-Err: %s", identifier, lookup.getErrorString()));
+
+            case Lookup.UNRECOVERABLE:
+                throw new PeppolInfrastructureException(String.format("SML lookup failed for identifier '%s' due to a data or server error. " +
+                        "Repeating the lookup immediately would not be helpful. DNS-Lookup-Err: %s", identifier, lookup.getErrorString()));
+
+            default:
+                throw new LookupException(String.format("Error when looking up identifier '%s' in SML. DNS-Lookup-Err: %s",
+                        identifier, lookup.getErrorString()));
+        }
+    }
+
 }

--- a/peppol-lookup/src/test/java/network/oxalis/vefa/peppol/lookup/LookupClientTest.java
+++ b/peppol-lookup/src/test/java/network/oxalis/vefa/peppol/lookup/LookupClientTest.java
@@ -24,7 +24,7 @@ import network.oxalis.vefa.peppol.common.lang.PeppolException;
 import network.oxalis.vefa.peppol.common.model.*;
 import network.oxalis.vefa.peppol.lookup.api.FetcherResponse;
 import network.oxalis.vefa.peppol.lookup.api.LookupException;
-import network.oxalis.vefa.peppol.lookup.api.NotFoundException;
+import network.oxalis.vefa.peppol.lookup.api.PeppolResourceException;
 import network.oxalis.vefa.peppol.lookup.fetcher.ApacheFetcher;
 import network.oxalis.vefa.peppol.lookup.fetcher.UrlFetcher;
 import network.oxalis.vefa.peppol.lookup.locator.BusdoxLocator;
@@ -35,7 +35,6 @@ import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpStatus;
 import org.testng.annotations.Test;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -461,7 +460,7 @@ public class LookupClientTest {
         assertNotNull(serviceMetadata);
     }
 
-    @Test(expectedExceptions = NotFoundException.class)
+    @Test(expectedExceptions = PeppolResourceException.class)
     public void noSmp() throws PeppolException {
         LookupClient client =
                 LookupClientBuilder.forMode(testMode)
@@ -472,7 +471,7 @@ public class LookupClientTest {
         System.out.println(dti);
     }
 
-    @Test(expectedExceptions = NotFoundException.class)
+    @Test(expectedExceptions = PeppolResourceException.class)
     public void noSmpApache() throws PeppolException {
         LookupClient client =
                 LookupClientBuilder.forMode(testMode)
@@ -483,7 +482,7 @@ public class LookupClientTest {
         client.getDocumentIdentifiers(ParticipantIdentifier.of("9908:no-smp"));
     }
 
-    @Test(expectedExceptions = NotFoundException.class)
+    @Test(expectedExceptions = PeppolResourceException.class)
     public void noSml() throws PeppolException {
         LookupClient client =
                 LookupClientBuilder.forMode(testMode)
@@ -565,7 +564,7 @@ public class LookupClientTest {
         }
 
         @Override
-        public FetcherResponse fetch(List<URI> uriFetchList) throws LookupException, FileNotFoundException {
+        public FetcherResponse fetch(List<URI> uriFetchList) throws LookupException {
             List<URI> wireMockUriFetchList = new ArrayList<URI>();
             for (URI uri : uriFetchList) {
                 uriList.add(uri);

--- a/peppol-lookup/src/test/java/network/oxalis/vefa/peppol/lookup/fetcher/ApacheFetcherTest.java
+++ b/peppol-lookup/src/test/java/network/oxalis/vefa/peppol/lookup/fetcher/ApacheFetcherTest.java
@@ -19,43 +19,261 @@
 
 package network.oxalis.vefa.peppol.lookup.fetcher;
 
-import network.oxalis.vefa.peppol.lookup.api.LookupException;
-import network.oxalis.vefa.peppol.lookup.api.MetadataFetcher;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import lombok.extern.slf4j.Slf4j;
+import network.oxalis.vefa.peppol.lookup.api.*;
 import network.oxalis.vefa.peppol.mode.Mode;
-import org.testng.annotations.Test;
+import org.testng.annotations.*;
 
 import java.io.FileNotFoundException;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.testng.Assert.*;
+
+@Slf4j
 public class ApacheFetcherTest {
 
-    private MetadataFetcher fetcher = new ApacheFetcher(Mode.of("TEST"));
+    private MetadataFetcher fetcher;
+    private WireMockServer wireMock;
+
+    @BeforeClass
+    public void setUp() {
+        fetcher = new ApacheFetcher(Mode.of("TEST"));
+        wireMock = new WireMockServer(wireMockConfig().dynamicPort());
+        wireMock.start();
+    }
+
+    @AfterClass
+    public void tearDown() {
+        wireMock.stop();
+    }
+
+    @BeforeMethod
+    public void resetStubs() {
+        wireMock.resetAll();
+    }
+
+    private List<URI> stubAndUri(int statusCode) {
+        wireMock.stubFor(get(urlEqualTo("/test"))
+                .willReturn(aResponse().withStatus(statusCode)));
+        return Collections.singletonList(URI.create(wireMock.baseUrl() + "/test"));
+    }
+
 
     @Test(expectedExceptions = LookupException.class)
-    public void simpleTimeout() throws LookupException, FileNotFoundException {
+    public void simpleTimeout() throws LookupException {
         List<URI> uriList = new ArrayList<URI>();
         uriList.add(URI.create("http://invalid.example.com/"));
         fetcher.fetch(uriList);
     }
 
-    @Test(expectedExceptions = {FileNotFoundException.class, LookupException.class})
-    public void simple404() throws LookupException, FileNotFoundException {
+    @Test(expectedExceptions = {LookupException.class})
+    public void simple404() throws LookupException {
         List<URI> uriList = new ArrayList<URI>();
         uriList.add(URI.create("http://httpstat.us/404"));
         fetcher.fetch(uriList);
     }
 
     @Test(expectedExceptions = LookupException.class)
-    public void simple500() throws LookupException, FileNotFoundException {
+    public void simple500() throws LookupException {
         List<URI> uriList = new ArrayList<URI>();
         uriList.add(URI.create("http://httpstat.us/500"));
         fetcher.fetch(uriList);
     }
 
     @Test(expectedExceptions = LookupException.class)
-    public void simpleNullPointer() throws LookupException, FileNotFoundException {
+    public void simpleNullPointer() throws LookupException {
         fetcher.fetch(null);
     }
+
+    // ════════════════════════════════════════════════════════════
+    // Data Providers
+    // ════════════════════════════════════════════════════════════
+
+    @DataProvider(name = "resourceNotFoundCodes")
+    public Object[][] resourceNotFoundCodes() {
+        return new Object[][]{
+                {404, "Participant metadata not found"},
+        };
+    }
+
+    @DataProvider(name = "infrastructureErrorCodes")
+    public Object[][] infrastructureErrorCodes() {
+        return new Object[][]{
+                {500, "SMP server error (HTTP 500)"},
+                {502, "SMP server error (HTTP 502)"},
+                {503, "SMP server error (HTTP 503)"},
+                {504, "SMP server error (HTTP 504)"},
+                {429, "Too many requests to SMP"},
+        };
+    }
+
+    @DataProvider(name = "unmappedHttpCodes")
+    public Object[][] unmappedHttpCodes() {
+        return new Object[][]{
+                {301, "Received HTTP status code 301"},
+                {400, "Received HTTP status code 400"},
+                {401, "Received HTTP status code 401"},
+                {403, "Received HTTP status code 403"},
+                {405, "Received HTTP status code 405"},
+
+        };
+    }
+
+
+    // ════════════════════════════════════════════════════════════
+    // HTTP Status Code → Exception Type Mapping
+    // ════════════════════════════════════════════════════════════
+
+    @Test(dataProvider = "resourceNotFoundCodes", groups = "http-status-mapping")
+    public void fetch_httpStatus_throwsPeppolResourceException(int statusCode, String expectedMsg) throws LookupException {
+
+        log.info("Testing HTTP status code {} for expected PeppolResourceException", statusCode);
+
+        // Arrange
+        List<URI> uriList = stubAndUri(statusCode);
+
+        try {
+            // Act
+            fetcher.fetch(uriList);
+            fail(String.format("Expected PeppolResourceException for HTTP %d", statusCode));
+        } catch (PeppolResourceException e) {
+            // Assert
+            assertTrue(e.getMessage().contains(expectedMsg),
+                    String.format("HTTP %d — expected message containing '%s' but got: %s", statusCode, expectedMsg, e.getMessage()));
+            assertNoFileNotFoundException(e, statusCode);
+        } catch (LookupException e) {
+            fail(String.format("HTTP %d — expected PeppolResourceException but got %s: %s", statusCode, e.getClass().getSimpleName(), e.getMessage()));
+        }
+    }
+
+    @Test(dataProvider = "infrastructureErrorCodes", groups = "http-status-mapping")
+    public void fetch_httpStatus_throwsPeppolInfrastructureException(int statusCode, String expectedMsg) throws LookupException {
+
+        log.info("Testing HTTP status code {} for expected PeppolInfrastructureException", statusCode);
+
+        // Arrange
+        List<URI> uriList = stubAndUri(statusCode);
+
+        try {
+            // Act
+            fetcher.fetch(uriList);
+            fail(String.format("Expected PeppolInfrastructureException for HTTP %d", statusCode));
+        } catch (PeppolInfrastructureException e) {
+            // Assert
+            assertTrue(e.getMessage().contains(expectedMsg),
+                    String.format("HTTP %d — expected message containing '%s' but got: %s", statusCode, expectedMsg, e.getMessage()));
+            assertNoFileNotFoundException(e, statusCode);
+        } catch (LookupException e) {
+            fail(String.format("HTTP %d — expected PeppolInfrastructureException but got %s: %s", statusCode, e.getClass().getSimpleName(), e.getMessage()));
+        }
+    }
+
+    @Test(dataProvider = "unmappedHttpCodes", groups = "http-status-mapping")
+    public void fetch_httpStatus_unmappedCodes_throwGenericLookupException(int statusCode, String expectedMsg) throws LookupException {
+
+        log.info("Testing HTTP status code {} for expected generic LookupException", statusCode);
+        // Arrange
+        List<URI> uriList = stubAndUri(statusCode);
+
+        try {
+            // Act
+            fetcher.fetch(uriList);
+            fail(String.format("Expected LookupException for HTTP %d", statusCode));
+        } catch (PeppolResourceException e) {
+            fail(String.format("HTTP %d — must NOT throw PeppolResourceException. Got: %s", statusCode, e.getMessage()));
+        } catch (PeppolInfrastructureException e) {
+            fail(String.format("HTTP %d — must NOT throw PeppolInfrastructureException. Got: %s", statusCode, e.getMessage()));
+        } catch (LookupException e) {
+
+            // Assert
+            assertTrue(e.getMessage().contains(expectedMsg),
+                    String.format("HTTP %d — expected message containing '%s' but got: %s", statusCode, expectedMsg, e.getMessage()));
+            assertNoFileNotFoundException(e, statusCode);
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════
+    // Network Failure Tests
+    // ════════════════════════════════════════════════════════════
+
+    @Test
+    public void fetch_unreachableHost_throwsNetworkFailureException() {
+
+        // Arrange
+        List<URI> uriList = Collections.singletonList(URI.create("http://invalid.example.com/"));
+
+        try {
+            // Act
+            fetcher.fetch(uriList);
+            fail("Expected NetworkFailureException for unreachable host");
+        } catch (NetworkFailureException e) {
+            // Assert
+            assertNotNull(e.getMessage());
+            assertNoFileNotFoundException(e, -1);
+        } catch (LookupException e) {
+            fail(String.format("Expected NetworkFailureException but got %s: %s", e.getClass().getSimpleName(), e.getMessage()));
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════
+    // Multi-URI Fallback Behaviour
+    // ════════════════════════════════════════════════════════════
+
+    @Test
+    public void fetch_multiUri_firstFailsSecondSucceeds_returnsResponse() throws LookupException {
+
+        // Arrange
+        wireMock.stubFor(get(urlEqualTo("/fail")).willReturn(aResponse().withStatus(503)));
+        wireMock.stubFor(get(urlEqualTo("/ok")).willReturn(aResponse().withStatus(200).withHeader("Content-Type", "text/xml").withBody("<root/>")));
+
+        List<URI> uriList = List.of(URI.create(wireMock.baseUrl() + "/fail"), URI.create(wireMock.baseUrl() + "/ok"));
+
+        // Act
+        FetcherResponse response = fetcher.fetch(uriList);
+
+        // Assert
+        assertNotNull(response);
+    }
+
+    @Test
+    public void fetch_multiUri_allFail_lastExceptionTypePreserved() {
+        // Arrange
+        wireMock.stubFor(get(urlEqualTo("/first")).willReturn(aResponse().withStatus(503)));
+        wireMock.stubFor(get(urlEqualTo("/second")).willReturn(aResponse().withStatus(404)));
+
+        List<URI> uriList = List.of(URI.create(wireMock.baseUrl() + "/first"), URI.create(wireMock.baseUrl() + "/second"));
+
+        try {
+            // Act
+            fetcher.fetch(uriList);
+            fail("Expected exception to be thrown when all URIs fail");
+        } catch (PeppolResourceException e) {
+            // Assert
+            assertTrue(e.getMessage().contains("not found"), "Expected 'not found' in message but got: " + e.getMessage());
+        } catch (LookupException e) {
+            fail(String.format("Expected PeppolResourceException (last URI was 404) but got %s: %s", e.getClass().getSimpleName(), e.getMessage()));
+        }
+    }
+
+
+    // ════════════════════════════════════════════════════════════
+    // FileNotFoundException Regression Guard
+    // ════════════════════════════════════════════════════════════
+    private void assertNoFileNotFoundException(Throwable thrown, int statusCode) {
+        Throwable current = thrown;
+        while (current != null) {
+            assertFalse(current instanceof FileNotFoundException,
+                    "FileNotFoundException must NEVER appear in the exception chain" +
+                            (statusCode > 0 ? " for HTTP " + statusCode : "") +
+                            ". Found at: " + current.getClass().getName() + ": " + current.getMessage());
+            current = current.getCause();
+        }
+    }
+
 }

--- a/peppol-lookup/src/test/java/network/oxalis/vefa/peppol/lookup/locator/BdxlLocatorTest.java
+++ b/peppol-lookup/src/test/java/network/oxalis/vefa/peppol/lookup/locator/BdxlLocatorTest.java
@@ -20,18 +20,37 @@
 package network.oxalis.vefa.peppol.lookup.locator;
 
 import network.oxalis.vefa.peppol.common.model.ParticipantIdentifier;
-import network.oxalis.vefa.peppol.lookup.api.MetadataLocator;
+import network.oxalis.vefa.peppol.lookup.api.LookupException;
+import network.oxalis.vefa.peppol.lookup.api.PeppolInfrastructureException;
+import network.oxalis.vefa.peppol.lookup.api.PeppolResourceException;
 import network.oxalis.vefa.peppol.mode.Mode;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
+import org.xbill.DNS.Lookup;
+import org.xbill.DNS.Type;
 
+import java.io.FileNotFoundException;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.URI;
+
+import static org.testng.Assert.*;
 
 public class BdxlLocatorTest {
 
+    private BdxlLocator locator;
+
+    @BeforeClass
+    public void setUp() {
+        locator = new BdxlLocator(Mode.of("TEST"));
+    }
+
     @Test
     public void simple() throws Exception {
-        MetadataLocator locator = new BdxlLocator(Mode.of("TEST"));
         Assert.assertEquals(
                 locator.lookup(ParticipantIdentifier.of("0192:923829644")),
                 URI.create("https://test-smp.elma-smp.no")
@@ -60,4 +79,129 @@ public class BdxlLocatorTest {
                 "http://test-smp.difi.no.publisher.acc.edelivery.tech.ec.europa.eu"
         );
     }
+
+
+    // ════════════════════════════════════════════════════════════
+    // Exception Type Contracts — Unregistered Participants
+    // ════════════════════════════════════════════════════════════
+
+    @Test(groups = "integration")
+    public void lookup_unregisteredParticipant_throwsPeppolResourceException() {
+        String identifier = "9999:does-not-exist-bdxl-test";
+
+        try {
+            locator.lookup(ParticipantIdentifier.of(identifier));
+            fail("Expected PeppolResourceException for unregistered participant");
+        } catch (PeppolResourceException e) {
+            assertEquals(e.getMessage(),
+                    String.format("Participant with identifier '%s' is not registered in SML. The host does not exist", identifier));
+        } catch (PeppolInfrastructureException e) {
+            System.err.printf("WARNING: Got PeppolInfrastructureException — likely a network issue, not a regression. Message: %s%n", e.getMessage());
+        } catch (LookupException e) {
+            fail(String.format("Expected PeppolResourceException but got %s: %s", e.getClass().getSimpleName(), e.getMessage()));
+        }
+    }
+
+    @Ignore
+    @Test(groups = "integration")
+    public void lookup_registeredParticipantNoRecords_throwsPeppolResourceException() {
+        String identifier = "0201:doxee_test";
+
+        try {
+            locator.lookup(ParticipantIdentifier.of(identifier));
+            fail("Expected PeppolResourceException for unregistered participant");
+        } catch (PeppolResourceException e) {
+            assertEquals(e.getMessage(),
+                    String.format("Participant with identifier '%s' is not registered in SML. " +
+                            "The Host exists, but has no records associated with the queried type", identifier));
+        } catch (LookupException e) {
+            fail(String.format("Expected PeppolResourceException but got %s: %s", e.getClass().getSimpleName(), e.getMessage()));
+        }
+    }
+
+
+    // ════════════════════════════════════════════════════════════
+    // Reflection Tests for Private Methods
+    // ════════════════════════════════════════════════════════════
+
+    @DataProvider(name = "lookupFailureCodes")
+    public Object[][] lookupFailureCodes() {
+        return new Object[][]{
+                {Lookup.HOST_NOT_FOUND, PeppolResourceException.class, "The host does not exist"},
+                {Lookup.TYPE_NOT_FOUND, PeppolResourceException.class, "The Host exists, but has no records associated with the queried type"},
+                {Lookup.TRY_AGAIN, PeppolInfrastructureException.class, "due to network error. Retry may help"},
+                {Lookup.UNRECOVERABLE, PeppolInfrastructureException.class, "due to a data or server error"},
+        };
+    }
+
+    @Test(dataProvider = "lookupFailureCodes")
+    public void testHandleLookupFailureUsingReflection(int dnsResultCode,
+                                                       Class<? extends Exception> expectedException,
+                                                       String partialMessage) throws Exception {
+        // 1. Prepare Arguments
+        String identifier = "0088:123456";
+        ParticipantIdentifier participant = ParticipantIdentifier.of(identifier);
+
+        // We need a Lookup object. Since we can't easily mock the final getResult()
+        // without PowerMock, we use your helper to create a real Lookup with a mocked result.
+        Lookup mockLookup = createLookupWithResult(dnsResultCode);
+
+        // 2. Use Reflection to get the private method
+        Method method = BdxlLocator.class.getDeclaredMethod("handleLookupFailure",
+                Lookup.class, ParticipantIdentifier.class);
+        method.setAccessible(true);
+
+        // 3. Invoke and Catch
+        try {
+            method.invoke(locator, mockLookup, participant);
+            fail("Method should have thrown an exception");
+        } catch (InvocationTargetException e) {
+            // Reflection wraps the actual exception in an InvocationTargetException
+            Throwable cause = e.getCause();
+
+            assertEquals(cause.getClass(), expectedException,
+                    "Should throw the correct exception type for code: " + dnsResultCode);
+            assertTrue(cause.getMessage().contains(partialMessage),
+                    "Error message should contain expected text");
+            assertTrue(cause.getMessage().contains(identifier),
+                    "Error message should contain the participant identifier");
+        }
+    }
+
+
+    // ════════════════════════════════════════════════════════════
+    // FileNotFoundException Regression Guard (#497, #666)
+    // ════════════════════════════════════════════════════════════
+
+    @Test(groups = "integration")
+    public void lookup_unregisteredParticipant_neverThrowsFileNotFoundException() {
+        try {
+            locator.lookup(ParticipantIdentifier.of("9999:fnf-rg-bdxl"));
+            fail("Expected PeppolResourceException for unregistered participant");
+        } catch (LookupException e) {
+            Throwable current = e;
+            while (current != null) {
+                assertFalse(current instanceof FileNotFoundException,
+                        String.format("FileNotFoundException must NEVER appear in the exception chain. Found: %s: %s",
+                                current.getClass().getName(), current.getMessage()));
+                current = current.getCause();
+            }
+        }
+    }
+
+
+    private Lookup createLookupWithResult(int resultCode) throws Exception {
+        Lookup lookup = new Lookup("test.example.com", Type.NAPTR);
+        lookup.run();
+
+        Field resultField = Lookup.class.getDeclaredField("result");
+        resultField.setAccessible(true);
+        resultField.setInt(lookup, resultCode);
+
+        // Verify value is unchanged
+        assertEquals(lookup.getResult(), resultCode, "Result field override failed");
+
+        return lookup;
+    }
+
 }

--- a/peppol-lookup/src/test/java/network/oxalis/vefa/peppol/lookup/locator/BusdoxLocatorTest.java
+++ b/peppol-lookup/src/test/java/network/oxalis/vefa/peppol/lookup/locator/BusdoxLocatorTest.java
@@ -19,19 +19,114 @@
 
 package network.oxalis.vefa.peppol.lookup.locator;
 
+import network.oxalis.vefa.peppol.common.model.ParticipantIdentifier;
 import network.oxalis.vefa.peppol.lookup.api.LookupException;
+import network.oxalis.vefa.peppol.lookup.api.PeppolInfrastructureException;
+import network.oxalis.vefa.peppol.lookup.api.PeppolResourceException;
 import network.oxalis.vefa.peppol.mode.Mode;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.xbill.DNS.Lookup;
+import org.xbill.DNS.Type;
 
-import static org.testng.Assert.assertEquals;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import static org.testng.Assert.*;
 
 public class BusdoxLocatorTest {
 
-    private BusdoxLocator busdoxLocator = new BusdoxLocator(Mode.of("PRODUCTION"));
+    private BusdoxLocator busdoxLocator;
+
+
+    @BeforeClass
+    public void setUp() {
+        busdoxLocator = new BusdoxLocator(Mode.of("PRODUCTION"));
+    }
 
     @Test
     public void simple() throws LookupException {
         assertEquals(busdoxLocator.lookup("0192:991825827").getHost(),
                 "B-9823154777831486f5f30f7f41385a2a.iso6523-actorid-upis.edelivery.tech.ec.europa.eu");
     }
+
+    // ════════════════════════════════════════════════════════════
+    // Exception Type Contracts — Unregistered Participants
+    // ════════════════════════════════════════════════════════════
+
+    @Test(groups = "integration")
+    public void lookup_unregisteredParticipant_throwsPeppolResourceException() {
+        String identifier = "9999:does-not-exist-busdox-test";
+
+        try {
+            busdoxLocator.lookup(ParticipantIdentifier.of(identifier));
+            fail("Expected PeppolResourceException for unregistered participant");
+        } catch (PeppolResourceException e) {
+            assertEquals(e.getMessage(),
+                    String.format("Participant with identifier '%s' is not registered in SML. The host does not exist", identifier));
+            assertNull(e.getCause());
+        } catch (PeppolInfrastructureException e) {
+            System.err.printf("WARNING: Got PeppolInfrastructureException — likely a network issue, not a regression. Message: %s%n", e.getMessage());
+        } catch (LookupException e) {
+            fail(String.format("Expected PeppolResourceException but got %s: %s", e.getClass().getSimpleName(), e.getMessage()));
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════
+    // handleLookupFailure() — DNS Result Code Mapping
+    // ════════════════════════════════════════════════════════════
+
+    @DataProvider(name = "lookupFailureCodes")
+    public Object[][] lookupFailureCodes() {
+        return new Object[][]{
+                {Lookup.HOST_NOT_FOUND, PeppolResourceException.class, "is not registered in SML. The host does not exist"},
+                {Lookup.TYPE_NOT_FOUND, PeppolResourceException.class, "is not registered in SML. The Host exists, but has no records associated with the queried type"},
+                {Lookup.TRY_AGAIN, PeppolInfrastructureException.class, "due to network error. Retry may help"},
+                {Lookup.UNRECOVERABLE, PeppolInfrastructureException.class, "due to a data or server error"},
+        };
+    }
+
+    @Test(dataProvider = "lookupFailureCodes")
+    public void handleLookupFailure_mapsResultCodeToCorrectException(int dnsResultCode, Class<? extends LookupException> expectedType, String expectedMsg) throws Exception {
+        String identifier = "9999:busdox-failure-test";
+        ParticipantIdentifier participant = ParticipantIdentifier.of(identifier);
+
+        Lookup lookup = createLookupWithResult(dnsResultCode);
+
+        Method method = BusdoxLocator.class.getDeclaredMethod("handleLookupFailure", Lookup.class, ParticipantIdentifier.class);
+        method.setAccessible(true);
+
+        try {
+            method.invoke(busdoxLocator, lookup, participant);
+            fail(String.format("Expected %s for DNS result code %d", expectedType.getSimpleName(), dnsResultCode));
+        } catch (InvocationTargetException e) {
+            Throwable actual = e.getCause();
+            assertEquals(actual.getClass(), expectedType,
+                    String.format("DNS result %d — expected %s but got %s: %s", dnsResultCode, expectedType.getSimpleName(), actual.getClass().getSimpleName(), actual.getMessage()));
+            assertTrue(actual.getMessage().contains(expectedMsg),
+                    String.format("DNS result %d — expected message containing '%s' but got: %s", dnsResultCode, expectedMsg, actual.getMessage()));
+            assertTrue(actual.getMessage().contains(identifier),
+                    String.format("DNS result %d — message should contain identifier '%s' but got: %s", dnsResultCode, identifier, actual.getMessage()));
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════
+    // Helper
+    // ════════════════════════════════════════════════════════════
+
+    private Lookup createLookupWithResult(int resultCode) throws Exception {
+        Lookup lookup = new Lookup("test.example.com", Type.A);
+        lookup.run();
+
+        Field resultField = Lookup.class.getDeclaredField("result");
+        resultField.setAccessible(true);
+        resultField.setInt(lookup, resultCode);
+
+        assertEquals(lookup.getResult(), resultCode, "Result field override failed");
+        return lookup;
+    }
+
+
 }


### PR DESCRIPTION
## Pull Request Description


Resolves #586, relates to oxalis#586, oxalis#666, Oxalis-AS4#158, vefa-peppol#56

Lookup failures are reported as generic a `LookupException`, and sometimes wrapping `FileNotFoundException`, making it difficult to distinguish resource/configuration failures from network related failures. As a result implementing or attempting retry is also challenging.

This change introduces a domain-specific exception taxonomy: Exceptions are derived from the discussion in Oxalis-AS4#158

```
  LookupException (base — existing, backward compatible)
  ├── PeppolResourceException — Peppol resource is not available, configuration updates are usually required.
  │       e.g. participant not in SML, SMP returns 404
  ├── PeppolInfrastructureException — Recoverable error and  document can be retried/resent
  │       e.g. SMP 5xx, DNS Lookup Results TRY_AGAIN, UNRECOVERABLE
  └── NetworkFailureException — transient, network failures, retry may help
           e.g. socket timeout, connection refused, unknown host at http
```

DNS layer (BdxlLocator, BusdoxLocator):
- HOST_NOT_FOUND / TYPE_NOT_FOUND -> `PeppolResourceException`
- TRY_AGAIN -> `PeppolInfrastructureException` (with UDP->TCP fallback)
- UNRECOVERABLE -> `PeppolInfrastructureException`

HTTP layer (ApacheFetcher, UrlFetcher):
- 404 -> PeppolResourceException
- 500/502/503/504 -> PeppolInfrastructureException
- Socket/timeout/DNS errors -> NetworkFailureException
- FileNotFoundException is no longer thrown anywhere

LookupClient:
- Removed `catch(FileNotFoundException)` blocks
- Retained existing API contracts - backwards compatible.
- All other exceptions propagate with correct type preserved

## Design Notes
- Extracted lookup method into individual private helper for readability purposes
- Lazy initialization of HttpClient for resource optimization

## Test Coverage
- noSML/noSMP tests now throw `PeppolResourceException`
- `BdxlLocatorTest` / `BusdoxLocatorTest`: DNS result code -> exception type mapping
- `ApacheFetcherTest`: HTTP status code -> exception type mapping (`WireMock`)
- `FileNotFoundException` regression guards across all layers


## Type of Pull Request

- [x] New feature/Enhancement - non-breaking change which adds functionality
- [x] Bug fix 
- [ ] Breaking change (Require Major version change?)

## Type of Change

- [ ] OpenPeppol AS2/AS4 specification
- [ ] OpenPeppol Spring/Fall release 
- [x] Oxalis software change or enhancement
- [ ] CEF change

## Pull Request Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas. But did not added unnecessary annotation/comment say @author name etc
- [x] I have checked my code for variable and method name and corrected grammar/spelling mistakes if any
- [x] I have made corresponding changes to the documentation where needed
- [ ] My changes generate no new/additional warnings
- [x] My change is not breaking or creating conflict with associated dependencies 
- [x] I have performed a self-review of my own code
- [x] I ran `mvn clean install` before commit and all tests run successfully 
- [x] I conducted basic QA to assure all features are working fine
- [x] My pull request generate no conflicts with `master` branch
- [ ] I requested code review from other team members
